### PR TITLE
irc: add support for irc account password.

### DIFF
--- a/fishroom/config.py.example
+++ b/fishroom/config.py.example
@@ -15,6 +15,7 @@ config = {
         'server': 'irc.freenode.net',
         'port': 6697,
         'nick': 'XiaoT',       # IRC nick name
+        'password': None,      # IRC account password, if nickname registered
         'ssl': True,
         'blacklist': [
             '[Olaf]',


### PR DESCRIPTION
This commit provides support for registered irc nickname by
passing "password" config to python3-irc connect() method.