### PR TITLE
Fixing typo

### DIFF
--- a/fishroom/plugins/stats.py
+++ b/fishroom/plugins/stats.py
@@ -77,7 +77,7 @@ def hualao(cmd, *args, **kwargs):
     msg += "Mean {:.2f} +/− {:.2f} per person , {:.2f} per {}".format(
         mean_person,
         std_person,
-        time_average.
+        time_average,
         time_unit
     )
 


### PR DESCRIPTION
Fixes a typo in the stats plugin.

	modified:   fishroom/plugins/stats.py