### PR TITLE
If sending join too fast, freenode will not respond

### DIFF
--- a/fishroom/IRC.py
+++ b/fishroom/IRC.py
@@ -68,8 +68,11 @@ class IRCHandle(BaseBotInstance):
 
     def on_welcome(self, conn, event):
         for c in self.channels:
+            logger.debug("checking is_channel: %s" % (c, ))
             if irc.client.is_channel(c):
+                logger.debug("trying to join: %s" % (c, ))
                 conn.join(c)
+                time.sleep(0.5)
 
     def on_join(self, conn, event):
         logger.info(event.source + ' ' + event.target)


### PR DESCRIPTION
I have tried to add more than 18 channels in IRC on freenode, then the connection cannot get through. IRC keeps "reconnecting". But if the channel number is 18 or less, connection can be established. After trying many times, I found the problem is `join` is called too fast. After adding a latency between each `join`, no error happens since then.

The reason I do not use `Throttle` or `set_rate_limit` from irc package, that one has some bug and the reference of irc connection is not passed probably. I can update the throttle method after I fix this bug.